### PR TITLE
feat: Add setting for Melee class filter

### DIFF
--- a/ClarityInChaos/ClarityInChaosPlugin.cs
+++ b/ClarityInChaos/ClarityInChaosPlugin.cs
@@ -23,6 +23,9 @@ namespace ClarityInChaos
                                (Service.Condition[ConditionFlag.BoundByDuty]
                                 && !Service.Condition[ConditionFlag.BetweenAreas]
                                 && !Service.Condition[ConditionFlag.OccupiedInCutSceneEvent]);
+    public bool IsMeleeClass => Configuration.DebugForceIsMeleeClass ||
+                               (Service.PlayerState.ClassJob.Value.JobType == 1) ||
+                               (Service.PlayerState.ClassJob.Value.JobType == 3);
 
     public ClarityInChaosPlugin(
         IDalamudPluginInterface pluginInterface,

--- a/ClarityInChaos/ClarityInChaosUI.cs
+++ b/ClarityInChaos/ClarityInChaosUI.cs
@@ -355,6 +355,12 @@ namespace ClarityInChaos
         config.OnlyInDuty = onlyInDuty;
         changed = true;
       }
+      var OnlyAsMeleeClass = config.OnlyAsMeleeClass;
+      if (config.Size != GroupingSize.Backup && config.Size != GroupingSize.Alliance && DrawOnlyAsMeleeClassCheckbox($"Only As Tank / Melee DPS", ref OnlyAsMeleeClass))
+      {
+        config.OnlyAsMeleeClass = OnlyAsMeleeClass;
+        changed = true;
+      }
 
       ImGui.EndTable();
 
@@ -373,6 +379,22 @@ namespace ClarityInChaos
 
       ImGui.TableSetColumnIndex(1);
       if (ImGui.Checkbox($"##{label}", ref onlyInDuty))
+      {
+        changed = true;
+      }
+
+      return changed;
+    }
+    private bool DrawOnlyAsMeleeClassCheckbox(string label, ref bool OnlyAsMeleeClass)
+    {
+      var changed = false;
+
+      ImGui.TableNextRow();
+      ImGui.TableSetColumnIndex(0);
+      ImGui.Text(label);
+
+      ImGui.TableSetColumnIndex(1);
+      if (ImGui.Checkbox($"##{label}", ref OnlyAsMeleeClass))
       {
         changed = true;
       }
@@ -617,6 +639,12 @@ namespace ClarityInChaos
           plugin.Configuration.DebugForceInDuty = forceInDuty;
           plugin.Configuration.Save();
         }
+        var forceIsMeleeClass = plugin.Configuration.DebugForceIsMeleeClass;
+        if (ImGui.Checkbox("Force Is Tank / Melee DPS", ref forceIsMeleeClass))
+        {
+          plugin.Configuration.DebugForceIsMeleeClass = forceIsMeleeClass;
+          plugin.Configuration.Save();
+        }
 
         ImGui.Unindent();
       }
@@ -625,7 +653,7 @@ namespace ClarityInChaos
     public override void Draw()
     {
       var groupSize = plugin.BattleEffectsConfigurator.GetCurrentGroupingSize();
-      var activeConfig = plugin.Configuration.GetConfigForGroupingSize(groupSize, plugin.BoundByDuty);
+      var activeConfig = plugin.Configuration.GetConfigForGroupingSize(groupSize, plugin.BoundByDuty, plugin.IsMeleeClass);
 
       DrawSectionMasterEnable(activeConfig);
 

--- a/ClarityInChaos/Configuration.cs
+++ b/ClarityInChaos/Configuration.cs
@@ -26,6 +26,7 @@ namespace ClarityInChaos
     public bool DebugForcePartySize = false;
     public int DebugPartySize = 0;
     public bool DebugForceInDuty = false;
+    public bool DebugForceIsMeleeClass = false;
 
     // the below exist just to make saving less cumbersome
     [NonSerialized]
@@ -102,11 +103,11 @@ namespace ClarityInChaos
         _ => Backup,
       };
     }
-
-    private ConfigForGroupingSize GetConfigForGroupingSizeNotInDuty(GroupingSize size)
+    private ConfigForGroupingSize GetConfigForGroupingSizeNotInDuty(GroupingSize size, bool IsMeleeClass)
     {
       var config = GetConfigForGroupingSize(size);
-      if (config.OnlyInDuty)
+
+      if (config.OnlyInDuty || (config.OnlyAsMeleeClass && !IsMeleeClass))
       {
         if (size == GroupingSize.Backup)
         {
@@ -114,13 +115,13 @@ namespace ClarityInChaos
         }
         else
         {
-          return GetConfigForGroupingSizeNotInDuty(size - 1);
+          return GetConfigForGroupingSizeNotInDuty(size - 1, IsMeleeClass);
         }
       }
       return config;
     }
 
-    public ConfigForGroupingSize GetConfigForGroupingSize(GroupingSize size, bool inDuty)
+    public ConfigForGroupingSize GetConfigForGroupingSize(GroupingSize size, bool inDuty, bool IsMeleeClass)
     {
       if (inDuty)
       {
@@ -128,7 +129,7 @@ namespace ClarityInChaos
       }
       else
       {
-        return GetConfigForGroupingSizeNotInDuty(size);
+        return GetConfigForGroupingSizeNotInDuty(size, IsMeleeClass);
       }
     }
   }
@@ -157,6 +158,7 @@ namespace ClarityInChaos
     public ObjectHighlightColor OthersHighlight { get; set; }
 
     public bool OnlyInDuty { get; set; }
+    public bool OnlyAsMeleeClass { get; set; }
   }
 
   public class ConfigForBackup : ConfigForGroupingSize

--- a/ClarityInChaos/UiSettingsConfigurator.cs
+++ b/ClarityInChaos/UiSettingsConfigurator.cs
@@ -233,7 +233,7 @@ namespace ClarityInChaos
     public void UIChange(GroupingSize size)
     {
 
-      var config = plugin.Configuration.GetConfigForGroupingSize(size, plugin.BoundByDuty);
+      var config = plugin.Configuration.GetConfigForGroupingSize(size, plugin.BoundByDuty, plugin.IsMeleeClass);
       BattleEffectSelf = config.Self;
       BattleEffectParty = config.Party;
       BattleEffectOther = config.Other;
@@ -252,7 +252,7 @@ namespace ClarityInChaos
 
     public void OnUpdate(IFramework framework)
     {
-      var activeConfig = plugin.Configuration.GetConfigForGroupingSize(GetCurrentGroupingSize(), plugin.BoundByDuty);
+      var activeConfig = plugin.Configuration.GetConfigForGroupingSize(GetCurrentGroupingSize(), plugin.BoundByDuty, plugin.IsMeleeClass);
 
       if (!plugin.Configuration.Enabled)
       {


### PR DESCRIPTION
This allows users to only have the filters applied when their job is a tank or melee DPS.

Based on a request from a party member who wants to see effects when ranged melee or DPS but wanted to keep the effects off when they would be up in the fight.


Realistically, there is some minor room for improvement with the checkbox function being duplicated since the label is provided along with the referenced setting.